### PR TITLE
Resolved performance issue when pulling in object constraints

### DIFF
--- a/cx_OracleObject/Statements.py
+++ b/cx_OracleObject/Statements.py
@@ -65,6 +65,7 @@ INDEXES = INDEXES_ANY + """
           ( select 1
             from %(p_ViewPrefix)s_constraints
             where owner = o.owner
+              and table_name = o.table_name
               and constraint_name = o.index_name
           )
         order by o.owner, o.index_name"""


### PR DESCRIPTION
Added an additional filter to the `INDEXES` statement to vastly improve query performance.

This has been tested against an Oracle 19c database and a schema containing 87 tables with indexes. Finished after about 60 seconds.